### PR TITLE
Questing Update v2.1

### DIFF
--- a/config/ftbquests/quests/chapters/allthemodium.snbt
+++ b/config/ftbquests/quests/chapters/allthemodium.snbt
@@ -33,7 +33,7 @@
 		{
 			x: 0.0d
 			y: 1.5d
-			description: ["Find this ore in the Nethers Warped Forests and Crimson Forests between Y100 to Y123, or the Other between Y0 to Y20."]
+			description: ["Find this ore in the Nether's Warped Forests and Crimson Forests between Y100 to Y123, or the Other between Y0 to Y20."]
 			hide_dependency_lines: false
 			dependencies: ["731686C758AD9A99"]
 			dependency_requirement: "one_started"
@@ -79,16 +79,11 @@
 				type: "item"
 				item: "ironfurnaces:allthemodium_furnace"
 			}]
-			rewards: [{
-				id: "434234EED2F21388"
-				type: "item"
-				item: "ironfurnaces:heater"
-			}]
 		}
 		{
 			x: -2.5d
 			y: 2.0d
-			description: ["It is recommended to use this potion with your first ingot. "]
+			description: ["t is recommended to craft this potion with your first ingot."]
 			dependencies: ["71A43C89EB13E9A0"]
 			id: "04AB01C841CD3E3F"
 			tasks: [{
@@ -136,7 +131,7 @@
 		{
 			x: 1.0d
 			y: 2.0d
-			description: ["It is recommended to use this potion with your first ingot. "]
+			description: [""]
 			dependencies: ["61FDABF2C7CC1F9D"]
 			id: "7496DB58411060AE"
 			tasks: [{
@@ -165,7 +160,7 @@
 		{
 			x: 4.5d
 			y: 2.0d
-			description: ["It is recommended to use this potion with your first ingot. "]
+			description: [""]
 			dependencies: ["44760B819EB3CA68"]
 			id: "76016E5C8C9397D2"
 			tasks: [{
@@ -219,11 +214,6 @@
 				id: "0B2932972CD2E73E"
 				type: "item"
 				item: "ironfurnaces:vibranium_furnace"
-			}]
-			rewards: [{
-				id: "75920A94628447C9"
-				type: "item"
-				item: "ironfurnaces:item_heater"
 			}]
 		}
 		{
@@ -302,7 +292,7 @@
 		{
 			x: 1.0d
 			y: 3.0d
-			description: ["My god this stuff is a lot more commen then I thought."]
+			description: ["My god this stuff is a lot more common then I thought."]
 			dependencies: ["7496DB58411060AE"]
 			id: "479B9579742354E1"
 			tasks: [{
@@ -326,7 +316,7 @@
 		{
 			x: 4.5d
 			y: 3.0d
-			description: ["Why cant I hold all these things."]
+			description: [""]
 			dependencies: ["76016E5C8C9397D2"]
 			id: "2D76BDEC76B0C788"
 			tasks: [{
@@ -723,6 +713,11 @@
 					}
 				}
 			}]
+			rewards: [{
+				id: "4D04379836E29120"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			x: -2.5d
@@ -853,7 +848,11 @@
 			icon: "minecraft:netherrack"
 			x: 1.0d
 			y: 9.5d
-			description: ["Here be dragons - you can find their skeletons scattered across the landscape, or fight a live one if you're feeling brave!"]
+			description: [
+				"A long time ago, dragons lived in these lands."
+				""
+				"There are no dragons to be found now, but Vibranium is abundant in The Other."
+			]
 			hide_dependency_lines: false
 			dependencies: ["5130BBAD5C542EDB"]
 			id: "1A5E414C9D25703A"

--- a/config/ftbquests/quests/chapters/basic_power_generation.snbt
+++ b/config/ftbquests/quests/chapters/basic_power_generation.snbt
@@ -145,6 +145,11 @@
 				type: "checkmark"
 				title: "Getting Started: Part 2 - Basic Power"
 			}]
+			rewards: [{
+				id: "2A6FF8DEB3D7A9B5"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			title: "Using Our Power"
@@ -154,7 +159,7 @@
 			description: [
 				"Let's make a Metallurgic Infuser."
 				""
-				"This item allows us to make a renewable energy source, the Wind Generator."
+				"This machine allows us to make several materials needed to make a renewable energy source, the Wind Generator."
 				""
 				"Place the Infuser beside the Coal Generator to give it power."
 			]
@@ -241,6 +246,8 @@
 				"Use the parts from the previous quest to create your first Wind Generator!"
 				""
 				"Wind Generators need to be placed in view of the sky, and the higher they are placed, the more power it generates!"
+				""
+				"*Note: If the noise is too much, you can install the muffling upgrade into the Generator."
 			]
 			dependencies: ["531DFFDE9EA7838E"]
 			size: 1.5d
@@ -261,6 +268,11 @@
 					id: "47BB20E97AF70BAE"
 					type: "xp"
 					xp: 10
+				}
+				{
+					id: "671BF1D485FD3478"
+					type: "item"
+					item: "mekanism:upgrade_muffling"
 				}
 			]
 		}
@@ -572,7 +584,6 @@
 					id: "7DF48E2657A34158"
 					type: "item"
 					item: "minecraft:redstone_block"
-					count: 2
 				}
 				{
 					id: "4F6159B4C39C586F"
@@ -813,9 +824,9 @@
 			y: -0.5d
 			subtitle: "The First of Many"
 			description: [
-				"Use the Crimson Steel to upgrade your pickaxe, and then let's find some Allthemodium Ore!"
+				"Use the Crimson Steel or Netherite to upgrade your pickaxe, and then let's find some Allthemodium Ore!"
 				""
-				"*Note: This is found in Mountain Biomes in the Overworld above Y:170"
+				"*Note: This is found in Mountainous biomes inside cave ceilings and walls, with additional deposits in peaks above Y170."
 			]
 			dependencies: [
 				"4713FBB21B859A3B"
@@ -1210,7 +1221,7 @@
 			description: [
 				"For your next mining-level upgrade, you'll need Vibranium."
 				""
-				"Vibranium can be found in the Nether in Crimson and Warped Forests, between the Y100 and Y123, and the Other from Y0 to Y20."
+				"Vibranium can be found in the Nether in Crimson and Warped Forests, between Y100 to Y123, and the Other from Y0 to Y20."
 			]
 			dependencies: ["746D39907C15027A"]
 			id: "75A0CAF9E85198EF"
@@ -1249,7 +1260,7 @@
 				id: "3918D137B6EDB405"
 				type: "item"
 				item: "minecraft:ender_pearl"
-				count: 16L
+				count: 12L
 			}]
 			rewards: [
 				{
@@ -1322,7 +1333,7 @@
 			x: 23.5d
 			y: 3.5d
 			shape: "square"
-			subtitle: "for the first time....."
+			subtitle: "For the first time....."
 			description: ["Head to the End and kill the Ender Dragon!"]
 			dependencies: [
 				"75A0CAF9E85198EF"
@@ -1416,7 +1427,7 @@
 			description: [
 				"Somewhere in the End, you'll find a floating ship."
 				""
-				"Defeat the enemies there, and you'll find yourself your first Elytra."
+				"Defeat the enemies there and make your way to the loot room, and you'll find yourself your first Elytra."
 			]
 			dependencies: ["1EC4BA2569828891"]
 			id: "427B251ABCD4B085"
@@ -1504,7 +1515,7 @@
 			y: -1.0d
 			subtitle: "Ancient... or something."
 			description: [
-				"Heading into the Nether, you can find yourself some Netherite for an upgrade!"
+				"Heading into the Nether, you can find yourself some Ancient Debris to create some Netherite for an upgrade!"
 				""
 				"Netherite also makes a great coating for Silent Gear items."
 			]
@@ -1514,6 +1525,11 @@
 				id: "7CC6167CF3372FEF"
 				type: "item"
 				item: "minecraft:netherite_ingot"
+			}]
+			rewards: [{
+				id: "60F0013E800D183C"
+				type: "xp"
+				xp: 100
 			}]
 		}
 		{
@@ -1570,7 +1586,7 @@
 			]
 		}
 		{
-			title: "Sticking with Mechanism"
+			title: "Sticking with Mekanism"
 			x: 6.5d
 			y: 0.0d
 			subtitle: "Leads to creating an ore FACTORY."
@@ -1598,7 +1614,7 @@
 				""
 				"You'll place a chest on both, and then use the Cogwheel in the Pulverizer to configure input and output. Turn the top face Blue (input) and the right face Red (Output). Make sure to press the \"Auto Eject\" and \"Auto Input\" buttons."
 				""
-				"In the Iron Furnace, you'll do the same thing, except Input from the right and Output to the top."
+				"In the Iron Furnace, you'll do the same thing, except Input from the left and Output to the top."
 			]
 			dependencies: ["7410CB313F03A6B5"]
 			id: "7FF2F202BE2AEF3E"
@@ -1630,9 +1646,9 @@
 			description: [
 				"To set up automated Ore smelting from Mekanism, place the Enrichment Chamber to the left of your Iron Furnace, and place a Chest on top of both."
 				""
-				"In the Enrichment Chamber, use the \"Side Config\" to input from the top, and output to the left. Make sure to press the \"Auto Eject\" button."
+				"In the Enrichment Chamber, use the \"Side Config\" to input from the top, and output to the right. Make sure to press the \"Auto Eject\" button."
 				""
-				"In the Iron Furnace, you'll do the same thing, except Input from the right and Output to the top."
+				"In the Iron Furnace, you'll do the same thing, except Input from the left and Output to the top."
 			]
 			dependencies: ["487F54A97A334E04"]
 			id: "216E75E350303F42"
@@ -1663,7 +1679,7 @@
 			description: [
 				"To get started with Mekanism, check out the &aMekanism&r Chapter in the &6Technology&r Group."
 				""
-				"&o To be Continued..."
+				"*Note: This quest chapter will be added in a later update.&o To be Continued..."
 			]
 			dependencies: ["216E75E350303F42"]
 			size: 1.5d
@@ -1686,7 +1702,7 @@
 			shape: "square"
 			subtitle: "Alloys are in your future."
 			description: [
-				"To get started with Thermal Expansion, check out the &aThermal Series&r Chapter in the &6Technology&r Group."
+				"Thermal Expansion is a simple power mod! The quest chapter will be added in a later update."
 				""
 				"&o To be Continued..."
 			]

--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -29,7 +29,7 @@
 			description: [
 				"Welcome to &aBotania&f!"
 				""
-				"Please refer to the &eLexica Botania &fin your &eAkashic Tome &ffor additional help with the mod."
+				"Please refer to the &eLexica Botania &fin your &eEccentric Tome &ffor additional help with the mod."
 			]
 			size: 1.5d
 			id: "3712DD92B446BB60"
@@ -45,30 +45,9 @@
 					item: "botania:flower_bag"
 				}
 				{
-					id: "3050309DCDB7533F"
-					type: "item"
-					item: {
-						id: "minecraft:player_head"
-						Count: 1b
-						tag: {
-							SkullOwner: {
-								Properties: {
-									textures: [{
-										Value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWQ3YzI3M2U5N2MyNzdjNDljOTA2NWVkZGYxMDdlODdlYTc3NWM4N2IyYzlmZWEwOTIyNTUwNTE5MDJhYzRhIn19fQ=="
-									}]
-								}
-								Id: [I;
-									-757981255
-									353128114
-									-1977494863
-									-538281118
-								]
-							}
-							display: {
-								Name: "{\"text\":\"BovineShaman\"}"
-							}
-						}
-					}
+					id: "544AF0D812BA96E5"
+					type: "xp"
+					xp: 10
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/bounty_board.snbt
+++ b/config/ftbquests/quests/chapters/bounty_board.snbt
@@ -472,7 +472,7 @@
 		{
 			x: 4.550000000000001d
 			y: 6.0d
-			subtitle: "More than Once."
+			subtitle: "This isn't even my final form."
 			size: 1.5d
 			id: "56DA46DC82F6665D"
 			tasks: [{
@@ -571,6 +571,11 @@
 					type: "xp"
 					xp: 100
 				}
+				{
+					id: "70505A07F2966850"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
 			]
 		}
 		{
@@ -582,7 +587,7 @@
 			tasks: [{
 				id: "0EA4B08DAAFA4287"
 				type: "kill"
-				title: "&l&9The End Bounty:&r&e Enderman"
+				title: "&l&9The End Bounty:&r&e Endermen"
 				icon: "tconstruct:enderman_head"
 				entity: "minecraft:enderman"
 				value: 5L
@@ -698,7 +703,7 @@
 			]
 		}
 		{
-			title: "&l&9Overworld Bounty:&r&e Creepers"
+			title: "&l&9Overworld Bounty:&r&e Spiders"
 			icon: "minecraft:spider_eye"
 			x: 2.0d
 			y: -0.5d

--- a/config/ftbquests/quests/chapters/elementalcraft.snbt
+++ b/config/ftbquests/quests/chapters/elementalcraft.snbt
@@ -85,7 +85,7 @@
 			description: [
 				"Welcome to &aElementalCraft&f!"
 				""
-				"The &eElementopedia&f in you &eAkashic Tome&f will guide you through the mod."
+				"The &eElementopedia&f in your&e Eccentric Tome&f will guide you through the mod."
 			]
 			size: 1.5d
 			id: "55F12D063F9D9430"
@@ -94,30 +94,9 @@
 				type: "checkmark"
 			}]
 			rewards: [{
-				id: "2C3A0CE67B4C644F"
-				type: "item"
-				item: {
-					id: "minecraft:player_head"
-					Count: 1b
-					tag: {
-						SkullOwner: {
-							Properties: {
-								textures: [{
-									Value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWQ3YzI3M2U5N2MyNzdjNDljOTA2NWVkZGYxMDdlODdlYTc3NWM4N2IyYzlmZWEwOTIyNTUwNTE5MDJhYzRhIn19fQ=="
-								}]
-							}
-							Id: [I;
-								-647195142
-								2010533167
-								-1243897687
-								1144171008
-							]
-						}
-						display: {
-							Name: "{\"text\":\"BovineShaman\"}"
-						}
-					}
-				}
+				id: "740DFA8F51630C10"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -226,6 +226,7 @@
 				id: "7F08D4E77359BF4A"
 				type: "item"
 				title: "Any #minecraft:wool"
+				icon: "minecraft:white_wool"
 				item: {
 					id: "itemfilters:tag"
 					Count: 1b
@@ -235,6 +236,18 @@
 				}
 				count: 3L
 			}]
+			rewards: [
+				{
+					id: "59024F65DCEB9DAA"
+					type: "item"
+					item: "minecraft:white_wool"
+				}
+				{
+					id: "1609AC17930BA465"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "It's Clippin' Time"
@@ -252,6 +265,11 @@
 						Damage: 0
 					}
 				}
+			}]
+			rewards: [{
+				id: "68AA10BF3AA0408A"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{
@@ -286,7 +304,7 @@
 			]
 		}
 		{
-			title: "Cows can't be Sheared."
+			title: "But....Cows can't be sheared..."
 			x: 6.0d
 			y: -1.0d
 			description: ["I don't wanna know how you got these."]
@@ -320,7 +338,7 @@
 			description: [
 				"Markets provide you with a villager than can sell you anything, if you have the right amount of emeralds."
 				""
-				"Spoiler: It's usually just 1 Emerald per item. BUT HE HAS EVERYTHING."
+				"Spoiler: It's usually just 1 Emerald per item. BUT THEY HAVE EVERYTHING."
 			]
 			dependencies: ["3EA883C0BB7BD38F"]
 			size: 1.5d
@@ -330,6 +348,18 @@
 				type: "item"
 				item: "farmingforblockheads:market"
 			}]
+			rewards: [
+				{
+					id: "2A90BE5DD251767D"
+					type: "item"
+					item: "minecraft:emerald"
+				}
+				{
+					id: "72142B51809511CF"
+					type: "xp"
+					xp: 100
+				}
+			]
 		}
 		{
 			title: "We're doing this the old fashioned way."
@@ -347,6 +377,11 @@
 				id: "63282E8604721F13"
 				type: "item"
 				item: "minecraft:lead"
+			}]
+			rewards: [{
+				id: "04DF879E17A497AD"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{
@@ -404,7 +439,8 @@
 				{
 					id: "75D8B76E11F272AC"
 					type: "item"
-					item: "pamhc2foodextended:omeletitem"
+					item: "croptopia:scrambled_eggs"
+					count: 2
 				}
 				{
 					id: "25D2B3D4AE631792"
@@ -436,15 +472,14 @@
 			]
 			rewards: [
 				{
-					id: "7CA76C249C92F750"
-					type: "item"
-					item: "pamhc2foodcore:chickennuggetitem"
-					count: 4
-				}
-				{
 					id: "7A84544510F1D4EE"
 					type: "xp"
 					xp: 10
+				}
+				{
+					id: "6ABAD303E8397549"
+					type: "item"
+					item: "croptopia:fried_chicken"
 				}
 			]
 		}
@@ -468,6 +503,19 @@
 				type: "checkmark"
 				title: "The Planter"
 			}]
+			rewards: [
+				{
+					id: "70556C33AE952F49"
+					type: "item"
+					item: "minecraft:wheat_seeds"
+					count: 2
+				}
+				{
+					id: "116FA96039FC2359"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Wheat."
@@ -513,7 +561,7 @@
 				{
 					id: "1C449D2589FD1836"
 					type: "item"
-					item: "pamhc2foodcore:toastitem"
+					item: "croptopia:toast"
 					count: 2
 				}
 				{
@@ -1098,6 +1146,18 @@
 				type: "item"
 				item: "minecraft:cake"
 			}]
+			rewards: [
+				{
+					id: "2C168199050CC470"
+					type: "item"
+					item: "minecraft:cake"
+				}
+				{
+					id: "7F528DE479E680AE"
+					type: "xp"
+					xp: 100
+				}
+			]
 		}
 		{
 			title: "You so sweet."
@@ -1113,6 +1173,19 @@
 				item: "minecraft:sugar"
 				count: 3L
 			}]
+			rewards: [
+				{
+					id: "7EAE8BCBABAA8B89"
+					type: "item"
+					item: "minecraft:sugar_cane"
+					count: 3
+				}
+				{
+					id: "04AB9DC101FCAB74"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Tree Harvesting"

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -40,9 +40,9 @@
 			x: -8.0d
 			y: 0.0d
 			shape: "hexagon"
-			subtitle: "Welcome to All The Mods 6"
+			subtitle: "Welcome to All The Mods 7"
 			description: [
-				"ATM6 has a ton of utilities to start you out. Veinminer is in the pack with FTB Ultamine. The default key is ~. You can change this in the keybind settings."
+				"ATM7 has a ton of utilities to start you out. Veinminer is in the pack with FTB Ultimine. The default key is ~. You can change this in the keybind settings."
 				""
 				"Go out and have some fun!"
 			]
@@ -66,7 +66,11 @@
 			x: -6.0d
 			y: 0.0d
 			subtitle: "The Start of Everyone's Journey"
-			description: ["Chop down a tree."]
+			description: [
+				"Chop down a tree."
+				""
+				"*Note: Any logs/planks will complete the quest."
+			]
 			dependencies: ["22C568A17B5D1B46"]
 			dependency_requirement: "one_completed"
 			id: "3001B2EEE5C6C9AB"
@@ -75,6 +79,7 @@
 					id: "1BB08F6BC4167067"
 					type: "item"
 					title: "Any #minecraft:logs"
+					icon: "minecraft:oak_log"
 					item: {
 						id: "itemfilters:tag"
 						Count: 1b
@@ -88,6 +93,7 @@
 					id: "63E6BD713B5AF4AE"
 					type: "item"
 					title: "Any #minecraft:planks"
+					icon: "minecraft:oak_planks"
 					item: {
 						id: "itemfilters:tag"
 						Count: 1b
@@ -256,6 +262,12 @@
 					type: "xp"
 					xp: 20
 				}
+				{
+					id: "72764D11BBFD56D2"
+					type: "item"
+					item: "minecraft:raw_iron"
+					count: 4
+				}
 			]
 		}
 		{
@@ -271,12 +283,17 @@
 				type: "checkmark"
 				title: "Silent Gear Tools"
 			}]
+			rewards: [{
+				id: "76A8806566716FF5"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			title: "Your Very First Knife"
 			x: -3.0d
 			y: -3.0d
-			subtitle: "My baby is all grown up."
+			subtitle: "Not just a stabbing tool."
 			description: [
 				"Combine 2 Sticks in the crafting table to create 2 Rough Rods. Then combine a rough rod with a piece of cobble to create a knife."
 				""
@@ -343,7 +360,6 @@
 					id: "588782323B6C8779"
 					type: "item"
 					item: "minecraft:iron_ingot"
-					count: 4
 				}
 				{
 					id: "4FC6999889B3BB90"
@@ -426,11 +442,19 @@
 				item: "waystones:warp_plate"
 				count: 2L
 			}]
-			rewards: [{
-				id: "79B4325D5FE8AC0E"
-				type: "item"
-				item: "waystones:warp_plate"
-			}]
+			rewards: [
+				{
+					id: "79B4325D5FE8AC0E"
+					type: "item"
+					item: "waystones:warp_plate"
+					count: 2
+				}
+				{
+					id: "7D2F568C9541B3E0"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Teleport Scrolls"
@@ -560,7 +584,7 @@
 					id: "5137D5DA40D41450"
 					type: "item"
 					item: "minecraft:iron_ingot"
-					count: 16
+					count: 8
 				}
 				{
 					id: "7D9E82A58FF438C1"
@@ -630,6 +654,11 @@
 				type: "checkmark"
 				title: "Better Tools"
 			}]
+			rewards: [{
+				id: "094E3F101DE493DA"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			title: "Start a Farm"
@@ -650,11 +679,19 @@
 				{
 					id: "270877E392533EC4"
 					type: "item"
-					item: {
+					title: "Any Hoe"
+					icon: {
 						id: "minecraft:stone_hoe"
 						Count: 1b
 						tag: {
 							Damage: 0
+						}
+					}
+					item: {
+						id: "itemfilters:tag"
+						Count: 1b
+						tag: {
+							value: "forge:tools/hoe"
 						}
 					}
 				}
@@ -686,13 +723,13 @@
 			]
 		}
 		{
-			title: "Farming and Food Chapter"
+			title: "Food and Farming Chapter"
 			icon: "minecraft:apple"
 			x: 6.0d
 			y: -2.0d
 			shape: "gear"
 			subtitle: "Getting Started with Food"
-			description: ["Get started by checking out the \"Farming and Food\" chapter."]
+			description: ["Learn about all things food by checking out the &aFood and Farming&r chapter."]
 			dependencies: ["1658780534451E39"]
 			size: 2.0d
 			id: "5ED547FE0A9CFC63"
@@ -700,6 +737,11 @@
 				id: "212FE7B11E7CA150"
 				type: "checkmark"
 				title: "Food and Farming"
+			}]
+			rewards: [{
+				id: "7452FA68B77452AA"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{
@@ -740,11 +782,19 @@
 				type: "item"
 				item: "rftoolspower:coalgenerator"
 			}]
-			rewards: [{
-				id: "627AC0B50101C5CE"
-				type: "xp"
-				xp: 10
-			}]
+			rewards: [
+				{
+					id: "44E15F1AD8E6807C"
+					type: "item"
+					item: "minecraft:redstone"
+					count: 4
+				}
+				{
+					id: "333830DA1521CB83"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Basic Ingots"
@@ -779,18 +829,19 @@
 					item: "minecraft:redstone"
 					count: 16L
 				}
+			]
+			rewards: [
 				{
-					id: "1CDB0A9B9CBBA334"
+					id: "7C5F7B3272E7C8A4"
 					type: "item"
-					item: "minecraft:diamond"
-					count: 3L
+					item: "minecraft:golden_apple"
+				}
+				{
+					id: "43B7BFD740A5BDE2"
+					type: "xp"
+					xp: 100
 				}
 			]
-			rewards: [{
-				id: "7C5F7B3272E7C8A4"
-				type: "item"
-				item: "minecraft:golden_apple"
-			}]
 		}
 		{
 			title: "Getting Started: Part 2"
@@ -800,7 +851,7 @@
 			shape: "gear"
 			subtitle: "Starting with Power and Beyond"
 			description: [
-				"ATM6 has plenty of Tech mods to get you started!"
+				"ATM7 has plenty of Tech mods to get you started!"
 				""
 				"If you're new to tech mods, check out the &aGetting Started: Part 2&r to get started!"
 			]
@@ -837,6 +888,11 @@
 				type: "checkmark"
 				title: "Growing Resources"
 			}]
+			rewards: [{
+				id: "7707A7BA2F7892B7"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			title: "Building Materials"
@@ -858,6 +914,7 @@
 					id: "2447018019B93BB7"
 					type: "item"
 					title: "Any #minecraft:logs"
+					icon: "minecraft:oak_log"
 					item: {
 						id: "itemfilters:tag"
 						Count: 1b
@@ -871,6 +928,7 @@
 					id: "07F5584697531C74"
 					type: "item"
 					title: "Any #minecraft:planks"
+					icon: "minecraft:oak_planks"
 					item: {
 						id: "itemfilters:tag"
 						Count: 1b
@@ -940,12 +998,19 @@
 					item: "mysticalagriculture:inferium_seeds"
 				}
 			]
-			rewards: [{
-				id: "3B61755CB8D2821B"
-				type: "item"
-				item: "mysticalagriculture:inferium_seeds"
-				count: 4
-			}]
+			rewards: [
+				{
+					id: "3B61755CB8D2821B"
+					type: "item"
+					item: "mysticalagriculture:inferium_seeds"
+					count: 2
+				}
+				{
+					id: "17FF55DC48B53E4D"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Storing Stuff"
@@ -959,6 +1024,7 @@
 				id: "56CC6703530D3AD8"
 				type: "item"
 				title: "Any #forge:chests"
+				icon: "minecraft:chest"
 				item: {
 					id: "itemfilters:tag"
 					Count: 1b
@@ -1013,7 +1079,7 @@
 				""
 				"Use the command &a/ftbteams party create&r to create your team."
 				""
-				"To claim chunks, open your map and click the \"Claim Chunks\" button in the top left. To claim a chunk, left click and drag to claim. To force load a chunk, Shift-Left Click the chunk. If done properly, you'll see lines across the chunk."
+				"To claim chunks, the default key to open the Claim Map is \"M\". To claim a chunk, left click and drag to claim. To force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."
 			]
 			dependencies: ["39C364C1D308A36E"]
 			id: "5E7C6705CE996BDF"
@@ -1033,6 +1099,7 @@
 			y: 1.5d
 			subtitle: "Portable Crafting!"
 			dependencies: ["34632E58F226ED0B"]
+			optional: true
 			id: "7DBCD01ABA2D029C"
 			tasks: [{
 				id: "3FB662A53432B6A6"
@@ -1066,7 +1133,8 @@
 				{
 					id: "5ED7A37C2D4EBEFC"
 					type: "item"
-					item: "minecraft:coal_block"
+					item: "minecraft:coal"
+					count: 8
 				}
 				{
 					id: "675AC559B2D13AE0"

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -9,6 +9,7 @@
 	default_hide_dependency_lines: false
 	quests: [
 		{
+			title: "Industrial Foregoing"
 			icon: {
 				id: "patchouli:guide_book"
 				Count: 1b
@@ -27,30 +28,9 @@
 				type: "checkmark"
 			}]
 			rewards: [{
-				id: "0BA0661996D457DE"
-				type: "item"
-				item: {
-					id: "minecraft:player_head"
-					Count: 1b
-					tag: {
-						SkullOwner: {
-							Properties: {
-								textures: [{
-									Value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWQ3YzI3M2U5N2MyNzdjNDljOTA2NWVkZGYxMDdlODdlYTc3NWM4N2IyYzlmZWEwOTIyNTUwNTE5MDJhYzRhIn19fQ=="
-								}]
-							}
-							Id: [I;
-								-647195142
-								2010533167
-								-1243897687
-								1144171008
-							]
-						}
-						display: {
-							Name: "{\"text\":\"BovineShaman\"}"
-						}
-					}
-				}
+				id: "0201A0D475099871"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{

--- a/config/ftbquests/quests/chapters/resourceful_ways.snbt
+++ b/config/ftbquests/quests/chapters/resourceful_ways.snbt
@@ -992,7 +992,7 @@
 		{
 			x: 0.0d
 			y: 0.0d
-			description: ["Note: Seeds will not grow a duplicate seed when harvested."]
+			description: ["Note: Seeds will not drop a duplicate seed when harvested."]
 			id: "1CC4F8570A7A99EB"
 			tasks: [{
 				id: "667004CD0469493D"

--- a/config/ftbquests/quests/chapters/silent_gear.snbt
+++ b/config/ftbquests/quests/chapters/silent_gear.snbt
@@ -37,19 +37,26 @@
 				type: "checkmark"
 				title: "Silent Gear Weapons, Tools and Armor"
 			}]
-			rewards: [{
-				id: "6FBB64122AC8F84B"
-				type: "item"
-				item: {
-					id: "silentgear:blueprint_package"
-					Count: 1b
-					tag: {
-						silentlib.LootContainer: {
-							LootTable: "silentgear:starter_blueprints"
+			rewards: [
+				{
+					id: "6FBB64122AC8F84B"
+					type: "item"
+					item: {
+						id: "silentgear:blueprint_package"
+						Count: 1b
+						tag: {
+							silentlib.LootContainer: {
+								LootTable: "silentgear:starter_blueprints"
+							}
 						}
 					}
 				}
-			}]
+				{
+					id: "383D184AE6F5236A"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "The Guide Book"
@@ -67,6 +74,11 @@
 				id: "2E0D0BBFC2D0BCAC"
 				type: "item"
 				item: "silentgear:guide_book"
+			}]
+			rewards: [{
+				id: "7004B19E09FEE74B"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{
@@ -93,7 +105,7 @@
 					id: "1CBB5DDFC361C0C6"
 					type: "item"
 					item: "silentgear:blueprint_paper"
-					count: 8
+					count: 4
 				}
 				{
 					id: "5079BE02B6810490"
@@ -615,7 +627,8 @@
 		{
 			x: 5.5d
 			y: 0.0d
-			subtitle: "Breaks down Silent Gear components."
+			subtitle: "Breaks down items into their components."
+			description: [""]
 			dependencies: ["15DE3BF0CBD8E0B4"]
 			id: "2EB96FF06627FD9A"
 			tasks: [{
@@ -780,18 +793,19 @@
 			title: "&5Starlight Charger"
 			x: 14.5d
 			y: 0.0d
+			shape: "diamond"
 			subtitle: "\"Enchanting\" Materials"
 			description: [
 				"The Starlight Charger can \"enchant\" materials with the \"Star Charged\" enchantment."
 				""
-				"A structure must be built, with the Starlight Charger in the middle in view of the night sky. It only gains Starlight Power during the night."
+				"A structure must be built with the Starlight Charger in the middle in view of the night sky. It only gains Starlight Power during the night."
 				""
 				"The Charger must be placed in the middle of a 7x7 structure, with a Pillar in each corner. Each pillar must have a \"Starlight Charger Cap\"."
 				""
 				"It also requires a charger catalyst per material."
 			]
 			dependencies: ["3930404D5C8B44EB"]
-			size: 1.5d
+			size: 1.75d
 			id: "7C3D763CF22D167A"
 			tasks: [{
 				id: "03C944C082828C47"
@@ -955,7 +969,8 @@
 		{
 			title: "Tier 1 Starlight Charger Pillar Cap"
 			x: 12.5d
-			y: -2.5d
+			y: -2.0d
+			shape: "circle"
 			description: [
 				"This is a Tier 1 Pillar Cap for the Starlight Charger structure."
 				""
@@ -986,7 +1001,8 @@
 		{
 			title: "Tier 2 Starlight Charger Pillar Cap"
 			x: 14.5d
-			y: -3.0d
+			y: -2.5d
+			shape: "circle"
 			description: ["This is a Tier 2 Pillar Cap for the Starlight Charger structure."]
 			dependencies: ["7C3D763CF22D167A"]
 			id: "29131C3532610ADF"
@@ -1013,7 +1029,8 @@
 		{
 			title: "Tier 3 Starlight Charger Pillar Cap"
 			x: 16.5d
-			y: -2.5d
+			y: -2.0d
+			shape: "circle"
 			description: ["This is a Tier 3 Pillar Cap for the Starlight Charger structure."]
 			dependencies: ["7C3D763CF22D167A"]
 			id: "3B560B2ECE331CAF"
@@ -1041,6 +1058,7 @@
 			title: "Tier 1 Starlight Charger Catalyst"
 			x: 13.5d
 			y: -1.0d
+			shape: "circle"
 			dependencies: ["7C3D763CF22D167A"]
 			id: "48D358470A019E7A"
 			tasks: [{
@@ -1066,6 +1084,7 @@
 			title: "Tier 2 Starlight Charger Catalyst"
 			x: 14.5d
 			y: -1.5d
+			shape: "circle"
 			dependencies: ["7C3D763CF22D167A"]
 			id: "2BF119DD5D977409"
 			tasks: [{
@@ -1091,6 +1110,7 @@
 			title: "Tier 3 Starlight Charger Catalyst"
 			x: 15.5d
 			y: -1.0d
+			shape: "circle"
 			dependencies: ["7C3D763CF22D167A"]
 			id: "0FEAD3CA2CC4A8B1"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -115,7 +115,7 @@
 			x: -1.0d
 			y: -1.5d
 			subtitle: "So much room for activities!"
-			description: ["The obsidian chest has the same storage capacity as a diamond chest, it just can't be blown up."]
+			description: ["Even MORE slots for storage and upgrades."]
 			dependencies: ["4C0BDD483CCB40C4"]
 			id: "77F241BEE9902751"
 			tasks: [{
@@ -366,30 +366,9 @@
 				title: "Storage"
 			}]
 			rewards: [{
-				id: "0F57A73B1DA8276A"
-				type: "item"
-				item: {
-					id: "minecraft:player_head"
-					Count: 1b
-					tag: {
-						SkullOwner: {
-							Properties: {
-								textures: [{
-									Value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWQ3YzI3M2U5N2MyNzdjNDljOTA2NWVkZGYxMDdlODdlYTc3NWM4N2IyYzlmZWEwOTIyNTUwNTE5MDJhYzRhIn19fQ=="
-								}]
-							}
-							Id: [I;
-								-647195142
-								2010533167
-								-1243897687
-								1144171008
-							]
-						}
-						display: {
-							Name: "{\"text\":\"BovineShaman\"}"
-						}
-					}
-				}
+				id: "570FFAC4E65BBF46"
+				type: "xp"
+				xp: 10
 			}]
 		}
 		{
@@ -417,11 +396,18 @@
 					item: "trashcans:energy_trash_can"
 				}
 			]
-			rewards: [{
-				id: "69AE6A259BD33878"
-				type: "item"
-				item: "trashcans:ultimate_trash_can"
-			}]
+			rewards: [
+				{
+					id: "69AE6A259BD33878"
+					type: "item"
+					item: "trashcans:ultimate_trash_can"
+				}
+				{
+					id: "5828D3729B49DFEC"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Dimensional Storage"
@@ -521,7 +507,7 @@
 			shape: "square"
 			subtitle: "Storage Drawers Distant Relative"
 			description: [
-				"Storage Drawers is a mod for storing stacks of the same items."
+				"Functional Storage is a mod for storing stacks of the same items."
 				""
 				"This is useful for items like Cobblestone, Dirt, etc."
 			]
@@ -550,7 +536,7 @@
 			x: -11.25d
 			y: -1.5d
 			shape: "square"
-			subtitle: "Upgradable Chests! (Sophisticated Backpacks' Older Brother)"
+			subtitle: "Upgradable Chests!"
 			description: [
 				"Sophisticated Chests allows you to upgrade your chests with metals to increase storage! You can also add upgrade filters to increase the functionality of the chest."
 				""
@@ -912,7 +898,8 @@
 		{
 			x: -7.5d
 			y: 6.5d
-			subtitle: "Allows the backpack to be emptied by Shift-Right Clicking an inventory."
+			subtitle: "Allows the backpack to be emptied."
+			description: ["Shift-Right Click an inventory to empty."]
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
 			hide: true
@@ -950,7 +937,7 @@
 		{
 			x: -3.0d
 			y: 5.0d
-			subtitle: "Keeps player's inventory stacked up from backpack."
+			subtitle: "Keeps the player's inventory stacked up from items in the backpack."
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
 			hide: true
@@ -1015,7 +1002,7 @@
 		{
 			x: -6.0d
 			y: 9.0d
-			subtitle: "Adds Smelting Tab to Backpack"
+			subtitle: "Adds a Smelting Tab to Backpack"
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
 			hide: true
@@ -1130,7 +1117,7 @@
 		{
 			x: 1.5d
 			y: 5.0d
-			subtitle: "Adds a Crafting Table Gui to the backpack."
+			subtitle: "Adds a Crafting Table GUI to the backpack."
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
 			hide: true
@@ -1191,7 +1178,7 @@
 			x: -1.5d
 			y: 4.0d
 			dependencies: ["7E9E03274A88347D"]
-			hide: true
+			hide: false
 			optional: true
 			id: "785951190FFDAA21"
 			tasks: [{
@@ -1209,7 +1196,7 @@
 			x: 0.0d
 			y: 4.0d
 			dependencies: ["785951190FFDAA21"]
-			hide: true
+			hide: false
 			optional: true
 			id: "0298A17C2AAC5765"
 			tasks: [{
@@ -1227,7 +1214,7 @@
 			x: 1.5d
 			y: 4.0d
 			dependencies: ["0298A17C2AAC5765"]
-			hide: true
+			hide: false
 			optional: true
 			id: "7AE3C8134F5ED726"
 			tasks: [{
@@ -1345,7 +1332,7 @@
 			subtitle: "Adds the ability to pump liquids from the tank upgrade."
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
-			hide: true
+			hide: false
 			optional: true
 			id: "6E9041744C592573"
 			tasks: [{
@@ -1363,7 +1350,7 @@
 			x: -6.0d
 			y: 4.0d
 			dependencies: ["6E9041744C592573"]
-			hide: true
+			hide: false
 			optional: true
 			id: "56B80A7EBFE21428"
 			tasks: [{
@@ -1381,7 +1368,7 @@
 			x: -4.5d
 			y: 4.0d
 			dependencies: ["56B80A7EBFE21428"]
-			hide: true
+			hide: false
 			optional: true
 			id: "6E3D53D1C4569A89"
 			tasks: [{
@@ -1409,8 +1396,13 @@
 				{
 					id: "10BF8798AEC3B008"
 					type: "item"
-					item: "minecraft:gold_ingot"
-					count: 4
+					item: {
+						id: "minecraft:potion"
+						Count: 1b
+						tag: {
+							Potion: "potionsmaster:gold_sight"
+						}
+					}
 				}
 				{
 					id: "588A8E368C4561A4"
@@ -1433,8 +1425,13 @@
 				{
 					id: "17E3F7A56B54895F"
 					type: "item"
-					item: "minecraft:diamond"
-					count: 4
+					item: {
+						id: "minecraft:potion"
+						Count: 1b
+						tag: {
+							Potion: "potionsmaster:diamond_sight"
+						}
+					}
 				}
 				{
 					id: "1CD2A81868C15FC6"

--- a/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -44,9 +44,10 @@
 			]
 		}
 		{
-			x: -1.0d
-			y: 5.0d
+			x: -1.5d
+			y: 5.5d
 			shape: "diamond"
+			subtitle: "Honey I Shrunk Myself"
 			description: ["Use this item to shrink. Helpful for working on automation and also just overall fun."]
 			id: "7EC8814940C4C3D7"
 			tasks: [{
@@ -62,8 +63,7 @@
 				{
 					id: "7CCC4171B93B35F0"
 					type: "item"
-					item: "compactmachines:wall"
-					count: 8
+					item: "botania:cosmetic_tiny_potato_mask"
 				}
 				{
 					id: "156D559B0B56BA9A"
@@ -150,13 +150,14 @@
 		}
 		{
 			x: -2.0d
-			y: 5.0d
+			y: 6.0d
 			subtitle: "When an infinite world is too small"
 			description: [
 				"It's an entire room in one block!"
 				""
 				"Higher tiers are even bigger on the inside."
 			]
+			dependencies: ["73F91BF3D424B269"]
 			id: "594540768120A627"
 			tasks: [{
 				id: "029DB3044D5E30A0"
@@ -165,12 +166,13 @@
 			}]
 			rewards: [
 				{
-					id: "17FAC4A27147E065"
+					id: "0325FA11C261E21D"
 					type: "item"
-					item: "compactmachines:personal_shrinking_device"
+					item: "compactmachines:wall"
+					count: 8
 				}
 				{
-					id: "5AB0E68060FA408D"
+					id: "10CFB937D14BE803"
 					type: "xp"
 					xp: 10
 				}
@@ -179,7 +181,7 @@
 		{
 			x: 3.5d
 			y: 5.5d
-			subtitle: "The Akhastic Tome's Distant Relative!"
+			subtitle: "The Akashic Tome's Distant Relative!"
 			description: [
 				"Stores all of the guidebooks you'll ever need!"
 				""
@@ -205,8 +207,8 @@
 			}]
 		}
 		{
-			x: -2.0d
-			y: 6.0d
+			x: -1.0d
+			y: 5.0d
 			description: [
 				"A quick way to switch between tools."
 				""
@@ -233,13 +235,10 @@
 			]
 		}
 		{
-			x: -1.0d
-			y: 6.0d
-			description: [
-				"Allows you to store multiple tools in one!"
-				""
-				"It'll automatically morph in to a mod's tool when looking at a block from that mod. You must add tools via crafting."
-			]
+			title: "Compact Machines"
+			x: -2.0d
+			y: 5.0d
+			description: ["This item is serves as the guide for Compact Machines, as well as the tool needed to teleport into your tiny machine worlds."]
 			id: "73F91BF3D424B269"
 			tasks: [{
 				id: "3B227EED4B839733"
@@ -331,13 +330,13 @@
 			rewards: [{
 				id: "2087EBA230655A8C"
 				type: "xp"
-				xp: 10
+				xp: 100
 			}]
 		}
 		{
 			title: "Building Wands"
-			x: -1.5d
-			y: 5.5d
+			x: -1.0d
+			y: 6.0d
 			description: [
 				"Can be helpful for building."
 				""
@@ -447,6 +446,11 @@
 				type: "checkmark"
 				title: "Tips and Tricks!"
 			}]
+			rewards: [{
+				id: "5FA6EA3609ABF6BE"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
 			icon: "minecraft:iron_ore"
@@ -457,7 +461,7 @@
 			description: [
 				"If you've played MC in previous versions, it's important to know that Ore Generation has changed as well as max build level."
 				""
-				"Make sure to check out the \"Ore Gen\" tab in the ore's recipe to see the Y level the ore generates!"
+				"Make sure to check out the \"World Gen\" tab in the ore's recipe to see the Y level the ore generates!"
 				""
 				""
 			]

--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -54,11 +54,13 @@
 		description: [
 			"Welcome to ATM7!"
 			""
-			"To get started with questing, check out the tabs on the left to get started!"
+			"To get started with questing, check out the tabs on the left to jump in!"
 			""
 			"If you are new to AllTheMods, make sure to check out the &aAllTheModium&r Chapter!"
 			""
 			"If you are new to modded MC, check out the &6Main Questline&r to help you get started."
+			""
+			"Note:  Mods are not gated by quests. Quests are optional."
 		]
 		size: 2.0d
 		optional: true


### PR DESCRIPTION
Changes:
> Various text descriptions, titles, and rewards have been fixed.
   - "Tips and Tricks" Chapter has changes to rewards and quest titles that are updated for 1.18
   - Fixed flavor text for Akashic Tome Subtitle
   - "Bounty Board" Spider quest renamed properly
   - "Getting Started" names have changed to reflect ATM7, several quest rewards and descriptions have been updated.
   - "Food and Farming" Chapter quests have been fixed.
   - "Allthemodium" had several description changes
   - Removed duplicate quest rewards across chapters
   - Prep Work for future quests