### PR TITLE
Feature: Add cobbled deepslate generation to IF Material Stonework Factory

### DIFF
--- a/kubejs/data/industrialforegoing/recipes/stonework_generate/deepslate.json
+++ b/kubejs/data/industrialforegoing/recipes/stonework_generate/deepslate.json
@@ -1,0 +1,12 @@
+{
+  "output": {
+    "item": "minecraft:cobbled_deepslate",
+    "count": 1
+  },
+  "waterNeed": 1000,
+  "lavaNeed": 1000,
+  "waterConsume": 0,
+  "lavaConsume": 0,
+  "type": "industrialforegoing:stonework_generate"
+}
+


### PR DESCRIPTION
Requires the same amount of lava and water as cobblestone and consumes neither.  This could be changed to consuming just like creating andesite/granite/diorite do.