### PR TITLE
ATM ores to laser drill

### DIFF
--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/azure_silver.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/azure_silver.json
@@ -1,0 +1,24 @@
+{
+    "output": {
+      "tag": "forge:raw_materials/azure_silver"
+    },
+    "rarity": [
+      {
+        "whitelist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+            "minecraft:end_highlands"
+          ]
+        },
+        "blacklist": {},
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 9
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens10"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/glowstone_dust.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/glowstone_dust.json
@@ -1,0 +1,25 @@
+{
+  "output": {
+    "tag": "forge:dusts/glowstone"
+  },
+  "rarity": [
+    {
+      "whitelist": {
+        "type": "minecraft:worldgen/biome",
+        "values": [
+          "minecraft:warped_forest",
+          "minecraft:crimson_forest"
+        ]
+      },
+      "blacklist": {},
+      "depth_min": 100,
+      "depth_max": 123,
+      "weight": 99
+    }
+  ],
+  "pointer": 0,
+  "catalyst": {
+    "item": "industrialforegoing:laser_lens13"
+  },
+  "type": "industrialforegoing:laser_drill_ore"
+}

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/obsidian.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/obsidian.json
@@ -1,0 +1,24 @@
+{
+    "output": {
+      "tag": "forge:obsidian"
+    },
+    "rarity": [
+      {
+        "whitelist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+            "minecraft:end_highlands"
+          ]
+        },
+        "blacklist": {},
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 90
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens10"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_allthemodium.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_allthemodium.json
@@ -1,6 +1,6 @@
 {
     "output": {
-      "tag": "forge:nuggets/allthemodium"
+      "tag": "forge:raw_materials/allthemodium"
     },
     "rarity": [
       {

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_allthemodium.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_allthemodium.json
@@ -1,0 +1,29 @@
+{
+    "output": {
+      "tag": "forge:nuggets/allthemodium"
+    },
+    "rarity": [
+      {
+        "whitelist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+            "minecraft:frozen_peaks",
+            "minecraft:jagged_peaks",
+            "minecraft:meadow",
+            "minecraft:snowy_slopes",
+            "minecraft:stony_peaks",
+            "byg:howling_peaks"
+          ]
+        },
+        "blacklist": {},
+        "depth_min": 32,
+        "depth_max": 80,
+        "weight": 4
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens4"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_unobtainium.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_unobtainium.json
@@ -1,0 +1,24 @@
+{
+    "output": {
+      "tag": "forge:raw_materials/unobtainium"
+    },
+    "rarity": [
+      {
+        "whitelist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+            "minecraft:end_highlands"
+          ]
+        },
+        "blacklist": {},
+        "depth_min": 30,
+        "depth_max": 60,
+        "weight": 1
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens10"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_vibranium.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_vibranium.json
@@ -1,6 +1,6 @@
 {
     "output": {
-      "tag": "forge:nuggets/vibranium"
+      "tag": "forge:raw_materials/vibranium"
     },
     "rarity": [
       {

--- a/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_vibranium.json
+++ b/kubejs/data/industrialforegoing/recipes/laser_drill_ore/raw_vibranium.json
@@ -1,0 +1,25 @@
+{
+    "output": {
+      "tag": "forge:nuggets/vibranium"
+    },
+    "rarity": [
+      {
+        "whitelist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+            "minecraft:warped_forest",
+            "minecraft:crimson_forest"
+          ]
+        },
+        "blacklist": {},
+        "depth_min": 100,
+        "depth_max": 123,
+        "weight": 1
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens13"
+    },
+    "type": "industrialforegoing:laser_drill_ore"
+  }


### PR DESCRIPTION
Adds atm ores to the laser drill, with proper biome whitelisting.

Other files exist to provide filler in order for their weights to work. 

Yellow lens provides allthemodium in mountain biomes. This pool is already saturated with gold and other ores, so didn't add anything here.

Green lens provides vibranium in warped and crimsons forests, as well as glowstone dust for filler. Originally played around with warped wart and nether wart blocks, but they returned barrier blocks for some reason, and I didn't want to detract from the already existing glowstone drill recipe so I made it dust instead. 

Purple lens provides unobtainium in end highlands with obsidian and azure silver for filler. Maybe reduce obsidian weight and add endstone?

In my testing it required a pretty substantial investment for the drills to provide respectable yields on the ores with these weights, that on top of the biome whitelisting requiring them to be built in certain places justifies raw ores over nuggets, but this can be changed if needed. 