### PR TITLE
disable spells

### DIFF
--- a/config/ars_nouveau/exchange.toml
+++ b/config/ars_nouveau/exchange.toml
@@ -1,0 +1,17 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = false
+	#Cost
+	#Range: > -2147483648
+	cost = 50
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "amplify=5"
+	augment_limits = []
+

--- a/config/ars_nouveau/place_block.toml
+++ b/config/ars_nouveau/place_block.toml
@@ -1,0 +1,17 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = false
+	#Cost
+	#Range: > -2147483648
+	cost = 10
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "amplify=5"
+	augment_limits = []
+


### PR DESCRIPTION
removes place block and exchange block due to exploitability in placing non whitelisted tile entities in the other dimension