### PR TITLE
Enable http ComputerCraft 

### DIFF
--- a/defaultconfigs/computercraft-server.toml
+++ b/defaultconfigs/computercraft-server.toml
@@ -33,7 +33,7 @@ command_require_creative = true
 #Controls the HTTP API
 [http]
 	#Enable the "http" API on Computers (see "rules" for more fine grained control than this).
-	enabled = false
+	enabled = true
 	#Enable use of http websockets. This requires the "http_enable" option to also be true.
 	websocket_enabled = false
 	#The number of http requests a computer can make at one time. Additional requests will be queued, and sent when the running requests have finished. Set to 0 for unlimited.

--- a/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
+++ b/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
@@ -45,22 +45,4 @@ onEvent('recipes', e => {
   e.smelting('allthemodium:unobtainium_allthemodium_alloy_ingot', 'allthemodium:unobtainium_allthemodium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_allthemodium_alloy_dust')
   e.smelting('allthemodium:unobtainium_vibranium_alloy_ingot', 'allthemodium:unobtainium_vibranium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_vibranium_alloy_dust')
 
-  e.custom({
-    "output": "{FluidName:\"allthemodium:soul_lava\",Amount:10}",
-    "rarity": [
-      {
-        "whitelist": {},
-        "blacklist": {},
-        "depth_min": 5,
-        "depth_max": 20,
-        "weight": 8
-      }
-    ],
-    "pointer": 0,
-    "catalyst": {
-      "item": "industrialforegoing:laser_lens11"
-    },
-    "entity": "minecraft:empty",
-    "type": "industrialforegoing:laser_drill_fluid"
-  })
 })

--- a/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
+++ b/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
@@ -44,5 +44,4 @@ onEvent('recipes', e => {
   e.smelting('allthemodium:vibranium_allthemodium_alloy_ingot', 'allthemodium:vibranium_allthemodium_alloy_dust').xp(.5).id('kubejs:smelting/vibranium_allthemodium_alloy_dust')
   e.smelting('allthemodium:unobtainium_allthemodium_alloy_ingot', 'allthemodium:unobtainium_allthemodium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_allthemodium_alloy_dust')
   e.smelting('allthemodium:unobtainium_vibranium_alloy_ingot', 'allthemodium:unobtainium_vibranium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_vibranium_alloy_dust')
-
 })

--- a/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
+++ b/kubejs/server_scripts/mod_specific/_allthemods/allthemodium.js
@@ -44,4 +44,23 @@ onEvent('recipes', e => {
   e.smelting('allthemodium:vibranium_allthemodium_alloy_ingot', 'allthemodium:vibranium_allthemodium_alloy_dust').xp(.5).id('kubejs:smelting/vibranium_allthemodium_alloy_dust')
   e.smelting('allthemodium:unobtainium_allthemodium_alloy_ingot', 'allthemodium:unobtainium_allthemodium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_allthemodium_alloy_dust')
   e.smelting('allthemodium:unobtainium_vibranium_alloy_ingot', 'allthemodium:unobtainium_vibranium_alloy_dust').xp(.5).id('kubejs:smelting/unobtainium_vibranium_alloy_dust')
+
+  e.custom({
+    "output": "{FluidName:\"allthemodium:soul_lava\",Amount:10}",
+    "rarity": [
+      {
+        "whitelist": {},
+        "blacklist": {},
+        "depth_min": 5,
+        "depth_max": 20,
+        "weight": 8
+      }
+    ],
+    "pointer": 0,
+    "catalyst": {
+      "item": "industrialforegoing:laser_lens11"
+    },
+    "entity": "minecraft:empty",
+    "type": "industrialforegoing:laser_drill_fluid"
+  })
 })


### PR DESCRIPTION
**Computer Craft setting :** 
Enabling the `http `option in Computer Craft. This one is used to be able to get programs from the internet like pastbin for example.

dissociate #1389
