### PR TITLE
433 tweaks

### DIFF
--- a/config/apotheosis/spawner.cfg
+++ b/config/apotheosis/spawner.cfg
@@ -141,6 +141,7 @@ spawn_eggs {
 	productivebees:yellow_black_carpenter_bee
 	artifacts:mimic
     twilightforest:swarm_spider
+    twilightforest:hedge_spider
      >
 }
 

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -304,12 +304,6 @@
 						Count: 1b
 						tag: {
 							mekData: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
 								FluidTanks: [{
 									Tank: 0b
 									stored: {
@@ -331,12 +325,6 @@
 						Count: 1b
 						tag: {
 							mekData: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
 								FluidTanks: [{
 									Tank: 0b
 									stored: {
@@ -854,12 +842,6 @@
 					Count: 1b
 					tag: {
 						mekData: {
-							owner: [I;
-								-1699457496
-								663964002
-								-2000923315
-								-13829450
-							]
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
@@ -885,33 +867,6 @@
 							ForgeCaps: { }
 							Items: [ ]
 							id: "mekanism:basic_fluid_tank"
-							Security: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
-								trusted: [[I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]]
-								name: "Security"
-								securityMode: 1
-								override: 0b
-								publicFreq: 1b
-							}
-							componentSecurity: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
-								securityMode: 0
-							}
 							redstone: 0b
 						}
 						display: {

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -156,12 +156,6 @@
 					Count: 1b
 					tag: {
 						mekData: {
-							owner: [I;
-								-1699457496
-								663964002
-								-2000923315
-								-13829450
-							]
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
@@ -187,27 +181,6 @@
 							ForgeCaps: { }
 							Items: [ ]
 							id: "mekanism:basic_fluid_tank"
-							Security: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
-								name: "Security"
-								securityMode: 0
-								override: 0b
-								publicFreq: 1b
-							}
-							componentSecurity: {
-								owner: [I;
-									-1699457496
-									663964002
-									-2000923315
-									-13829450
-								]
-								securityMode: 0
-							}
 							redstone: 0b
 						}
 						display: {

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -4886,7 +4886,6 @@
 			subtitle: "Self Contained"
 			description: ["When installed, this upgrade makes your bees permanently stay in the beehive. Because of this, you'll need to place the required flower block directly in front of the hive."]
 			dependencies: ["66324D7D0C51AEAC"]
-			dependency_requirement: "all_started"
 			id: "61AE0ECD03F2AB88"
 			tasks: [{
 				id: "524FB14DE5E8DB8E"

--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -937,7 +937,7 @@
 		}
 		{
 			x: -5.0d
-			y: 0.5d
+			y: 0.2d
 			shape: "hexagon"
 			subtitle: "Increases Bee Productivity by 140%"
 			dependencies: ["66324D7D0C51AEAC"]
@@ -962,7 +962,7 @@
 		}
 		{
 			x: -2.5d
-			y: -0.5d
+			y: -0.6d
 			subtitle: "Sonic Bees"
 			description: [
 				"Can be placed in a hive or centrifuge."
@@ -994,8 +994,8 @@
 			]
 		}
 		{
-			x: -3.5d
-			y: 2.0d
+			x: -3.0d
+			y: 1.9d
 			shape: "hexagon"
 			subtitle: "Making Babies"
 			description: [
@@ -1027,7 +1027,7 @@
 		}
 		{
 			x: -4.5d
-			y: -0.5d
+			y: -0.6d
 			shape: "hexagon"
 			subtitle: "Lumber and Quarry Bees will give Blocks instead of Chips"
 			dependencies: ["66324D7D0C51AEAC"]
@@ -1077,8 +1077,8 @@
 			]
 		}
 		{
-			x: -2.5d
-			y: 1.5d
+			x: -2.2d
+			y: 1.3d
 			shape: "hexagon"
 			subtitle: "Increases the Range of a Machine"
 			description: ["Mostly for the Catcher."]
@@ -1103,8 +1103,8 @@
 			]
 		}
 		{
-			x: -4.5d
-			y: 1.5d
+			x: -4.8d
+			y: 1.2d
 			shape: "hexagon"
 			subtitle: "Used to add Bees to a Filter"
 			dependencies: ["66324D7D0C51AEAC"]
@@ -1129,7 +1129,7 @@
 		}
 		{
 			x: -2.0d
-			y: 0.5d
+			y: 0.2d
 			subtitle: "Extracts Genes from Bees in Hives"
 			dependencies: ["66324D7D0C51AEAC"]
 			id: "1DF026030780AE96"
@@ -3219,7 +3219,7 @@
 					Count: 1b
 					tag: {
 						EntityTag: {
-							type: "productivebees:pepto_bismol"
+							type: "productivebees:sugarbag_honeycomb"
 						}
 					}
 				}
@@ -3229,7 +3229,7 @@
 					tag: {
 						value: {
 							EntityTag: {
-								type: "productivebees:pepto_bismol"
+								type: "productivebees:sugarbag_honeycomb"
 							}
 						}
 					}
@@ -4879,6 +4879,32 @@
 				type: "xp"
 				xp: 100
 			}]
+		}
+		{
+			x: -4.0d
+			y: 1.9d
+			subtitle: "Self Contained"
+			description: ["When installed, this upgrade makes your bees permanently stay in the beehive. Because of this, you'll need to place the required flower block directly in front of the hive."]
+			dependencies: ["66324D7D0C51AEAC"]
+			dependency_requirement: "all_started"
+			id: "61AE0ECD03F2AB88"
+			tasks: [{
+				id: "524FB14DE5E8DB8E"
+				type: "item"
+				item: "productivebees:upgrade_simulator"
+			}]
+			rewards: [
+				{
+					id: "21BDE3CBAF62A2C2"
+					type: "item"
+					item: "productivebees:honey_treat"
+				}
+				{
+					id: "65E721E100F6AF24"
+					type: "xp"
+					xp: 100
+				}
+			]
 		}
 	]
 }

--- a/config/reliquary-common.toml
+++ b/config/reliquary-common.toml
@@ -389,7 +389,7 @@ mobDropsEnabled = true
 		#Whether entities get angry at player if stealing fails
 		angerOnStealFailure = true
 		#Allows switching stealing from player on and off
-		stealFromPlayers = true
+		stealFromPlayers = false
 
 	#Seeker Shot settings
 	[items.seekerShot]

--- a/config/supplementaries-registry.toml
+++ b/config/supplementaries-registry.toml
@@ -91,3 +91,5 @@
 	#WIP
 	present = true
 
+[items]
+	shulker_shell = false

--- a/kubejs/client_scripts/jei_removals.js
+++ b/kubejs/client_scripts/jei_removals.js
@@ -47,6 +47,9 @@ onEvent('jei.hide.items', e => {
     'thermal:raw_lead',
     'thermal:raw_silver',
     'thermal:raw_nickel',
+    'ftbic:diamond_dust',
+    'thermal:diamond_dust',
+    'createaddition:diamond_grit'
   ])
 
   ftbicMetals.forEach(metal => {

--- a/kubejs/data/hostilenetworks/data_models/thermal_basalz.json
+++ b/kubejs/data/hostilenetworks/data_models/thermal_basalz.json
@@ -1,0 +1,23 @@
+{
+	"type": "thermal:basalz",
+	"name": "entity.thermal.basalz",
+	"name_color": "0xE8E8E8",
+	"gui_scale": 1,
+	"gui_x_offset": 0,
+	"gui_y_offset": 0,
+	"gui_z_offset": 0,
+	"sim_cost": 128,
+	"input": {
+		"item": "hostilenetworks:empty_prediction"
+	},
+	"base_drop": {
+		"item": "hostilenetworks:nether_prediction"
+	},
+	"trivia": "",
+	"fabricator_drops": [
+		{
+			"item": "thermal:basalz_rod",
+			"count": 4
+		}
+	]
+}

--- a/kubejs/data/hostilenetworks/data_models/thermal_blitz.json
+++ b/kubejs/data/hostilenetworks/data_models/thermal_blitz.json
@@ -1,0 +1,23 @@
+{
+	"type": "thermal:blitz",
+	"name": "entity.thermal.blitz",
+	"name_color": "0xE8E8E8",
+	"gui_scale": 1,
+	"gui_x_offset": 0,
+	"gui_y_offset": 0,
+	"gui_z_offset": 0,
+	"sim_cost": 128,
+	"input": {
+		"item": "hostilenetworks:empty_prediction"
+	},
+	"base_drop": {
+		"item": "hostilenetworks:nether_prediction"
+	},
+	"trivia": "",
+	"fabricator_drops": [
+		{
+			"item": "thermal:blitz_rod",
+			"count": 4
+		}
+	]
+}

--- a/kubejs/data/hostilenetworks/data_models/thermal_blizz.json
+++ b/kubejs/data/hostilenetworks/data_models/thermal_blizz.json
@@ -1,0 +1,23 @@
+{
+	"type": "thermal:blizz",
+	"name": "entity.thermal.blizz",
+	"name_color": "0xE8E8E8",
+	"gui_scale": 1,
+	"gui_x_offset": 0,
+	"gui_y_offset": 0,
+	"gui_z_offset": 0,
+	"sim_cost": 128,
+	"input": {
+		"item": "hostilenetworks:empty_prediction"
+	},
+	"base_drop": {
+		"item": "hostilenetworks:nether_prediction"
+	},
+	"trivia": "",
+	"fabricator_drops": [
+		{
+			"item": "thermal:blizz_rod",
+			"count": 4
+		}
+	]
+}

--- a/kubejs/server_scripts/mod_specific/_allthemods/atm_star.js
+++ b/kubejs/server_scripts/mod_specific/_allthemods/atm_star.js
@@ -9,21 +9,21 @@ onEvent('recipes', e => {
     B: 'minecraft:dragon_breath',
     S: 'botania:dragonstone',
     E: 'forbidden_arcanus:golden_dragon_scale',
-    I: Item.of('blue_skies:nature_arc', '{ArcLevel:2}')
+    I: [Item.of('blue_skies:nature_arc', '{ArcLevel:2}'),Item.of('blue_skies:nature_arc', '{ArcLevel:1}')]
   }).id('kubejs:allthetweaks/dragon_soul')
   //#endregion
   
   //#region Dimensional Seed
   maInfusion(e, 'allthetweaks:dimensional_seed',
-      'allthecompressed:emerald_block_6x',
-      'allthecompressed:blackstone_block_7x',
+      'allthecompressed:emerald_block_5x',
+      'allthecompressed:blackstone_block_6x',
       'allthecompressed:end_stone_block_5x',
-      'allthecompressed:netherrack_block_7x',
+      'allthecompressed:netherrack_block_6x',
       'allthecompressed:clay_block_5x',
       'allthecompressed:soul_sand_block_4x',
       'allthecompressed:red_sand_block_4x',
       'allthecompressed:red_sand_block_4x',
-      'allthecompressed:obsidian_block_6x')
+      'allthecompressed:obsidian_block_5x')
   //#endregion
   
   //#region Withers Compass

--- a/kubejs/server_scripts/mod_specific/mekanism/cobalt.js
+++ b/kubejs/server_scripts/mod_specific/mekanism/cobalt.js
@@ -230,4 +230,17 @@ onEvent('recipes', event => {
             "item": "kubejs:cobalt_dust"
         }
     }).id('kubejs:processing/cobalt/dust/from_dirty_dust')
+  
+     event.custom({
+        "type": "mekanism:enriching",
+        "input": {
+            "ingredient": {
+                "tag": "forge:storage_blocks/raw_cobalt"
+            }
+        },
+        "output": {
+            "item": "kubejs:cobalt_dust",
+            "count": 12
+        }
+    }).id('kubejs:processing/cobalt/dust/from_raw_block')
 })

--- a/kubejs/server_scripts/mod_specific/refinedstorage/refinedstorage.js
+++ b/kubejs/server_scripts/mod_specific/refinedstorage/refinedstorage.js
@@ -129,7 +129,7 @@
   })
   removeRecipeByID(e, [
     'extradisks:part/1024k_storage_part',
-    'refinedstorage:part/4096k_fluid_storage_part',
+    'refinedstorage:4096k_fluid_storage_part',
     'extradisks:part/4096k_storage_part',
     'extradisks:part/16384k_fluid_storage_part',
     'extradisks:part/16384k_storage_part',

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -4,7 +4,7 @@ onEvent('tags.blocks', e => {
   e.add('ae2:blacklisted/spatial','#forge:relocation_not_supported')
   e.add('allthemodium:blocks/blocklist',['alltheores:iridium_slate_ore'])
   e.add('minecraft:climbable', ['minecraft:chain', /additionallanterns:.*_chain/])
-  e.add('forge:relocation_not_supported', [/productivebees:.+/, 'minecraft:beehive', 'minecraft:bee_nest', /integrateddynamics:.+/,/botania:.+/])
+  e.add('forge:relocation_not_supported', [/productivebees:.+/, 'minecraft:beehive', 'minecraft:bee_nest', /integrateddynamics:.+/,/botania:.+/, '@waystones'])
   e.add('minecraft:mineable/axe', ['integrateddynamics:menril_log_stripped', 'integrateddynamics:menril_wood_stripped'])
   e.add('minecraft:logs', ['integrateddynamics:menril_log_stripped', 'integrateddynamics:menril_wood_stripped', 'evilcraft:undead_log_stripped', 'evilcraft:undead_wood_stripped', /allthemodium:stripped_\w+_log/])
 })
@@ -39,7 +39,12 @@ onEvent('tags.items', e => {
   e.remove('forge:silicon', 'ftbic:silicon')
 
   e.add('forge:melons','minecraft:melon_slice')
-  e.add('forbidden_arcanus:modifier/eternal_incompatible',['#alltheores:ore_hammers','@ftbic','#tconstruct:modifiable','minecraft:nether_star','mythicbotany:faded_nether_star', 'bloodmagic:sanguinereverter'])
+  e.add('forbidden_arcanus:modifier/eternal_incompatible',[
+    '#alltheores:ore_hammers','@ftbic','#tconstruct:modifiable',
+    'minecraft:nether_star','mythicbotany:faded_nether_star', 
+    'bloodmagic:sanguinereverter', 'elementalcraft:receptacle', 'elementalcraft:receptacle_empty', 
+    'elementalcraft:receptacle_improved', 'elementalcraft:receptacle_improved_empty'
+  ])
 
   // fix raw block crafting for other mods
   e.add('forge:raw_ores/zinc', 'create:raw_zinc')

--- a/kubejs/server_scripts/unify.js
+++ b/kubejs/server_scripts/unify.js
@@ -902,6 +902,7 @@ onEvent('recipes', e => {
   // recipe fixes
   e.replaceInput({id:'littlecontraptions:contraption_barge'}, 'create:brass_ingot', '#forge:ingots/brass')
   e.replaceOutput({}, '#forge:dusts/diamond', 'alltheores:diamond_dust')
+  e.remove({type: 'immersiveengineering:metal_press', output: 'minecraft:blaze_rod'})
 
   removeRecipeByID(e, [
     'immersiveengineering:crusher/nether_gold',

--- a/kubejs/server_scripts/unify.js
+++ b/kubejs/server_scripts/unify.js
@@ -901,6 +901,7 @@ onEvent('recipes', e => {
 
   // recipe fixes
   e.replaceInput({id:'littlecontraptions:contraption_barge'}, 'create:brass_ingot', '#forge:ingots/brass')
+  e.replaceOutput({}, '#forge:dusts/diamond', 'alltheores:diamond_dust')
 
   removeRecipeByID(e, [
     'immersiveengineering:crusher/nether_gold',


### PR DESCRIPTION
Additions
Add Simulator upgrade to hive upgrades in the Productive Bees Quest page
Added Thermal Basalz, Blitz, and Blizz to HNN
Added Raw cobalt chunk blocks to dust Mekanism enriching

Fixes
Blacklist Source Receptacles from the eternal stella, #1425 
Relocation blacklist waystones, #1516 
Edited Pepto Beesmol quest to accept sugarbag combs instead, #1437, #1526 
Fixed Latex, pink slime, liquid meat, and ethergas tank owner in IF quests
Further tweaks to the ATM star ingredients costs
Ban hedge spider from spawners
Rod of Lyssa, disable stealing from players
Unify Diamond dusts
Remove blaze rods to powder recipe, removes a item dupe
Fixed the Sgear shulker dust issue